### PR TITLE
Update Tweak.x for iOS 14.0

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -15,7 +15,12 @@
 %end
 
 %hook PRXFlowConfiguration
+// Works for >15.0
 -(void)setSupportsDarkMode:(BOOL)arg1 {
 	%orig(YES);
+}
+// Works for >14.0 (Should work for any iOS ver. with method
+-(BOOL)supportsDarkMode {
+	return YES;
 }
 %end


### PR DESCRIPTION
Add supportsDarkMode in use for older versions than iOS 15